### PR TITLE
Dockerfile that builds cuda kernels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM pytorch/pytorch:1.8.0-cuda11.1-cudnn8-devel
+ENV CUDA_HOME=/usr/local/cuda-11.1/
+# requirements
+RUN apt update --allow-unauthenticated --allow-insecure-repositories && DEBIAN_FRONTEND=noninteractive apt install -y python3-opencv
+RUN pip install mmcv-full==1.4.4 mmsegmentation==0.22.1  
+RUN pip install timm tqdm thop tensorboard ipdb h5py ipython Pillow==9.5.0 
+RUN pip install -U numpy 
+
+WORKDIR /completion_former 
+COPY . /completion_former
+RUN cd src/model/deformconv/ && CUDA_HOME=/usr/local/cuda-11.1/ python setup.py build install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM pytorch/pytorch:1.8.0-cuda11.1-cudnn8-devel
 ENV CUDA_HOME=/usr/local/cuda-11.1/
 # requirements
-RUN apt update --allow-unauthenticated --allow-insecure-repositories && DEBIAN_FRONTEND=noninteractive apt install -y python3-opencv
+RUN apt update --allow-unauthenticated --allow-insecure-repositories && \
+    DEBIAN_FRONTEND=noninteractive apt install -y python3-opencv
 RUN pip install mmcv-full==1.4.4 mmsegmentation==0.22.1  
 RUN pip install timm tqdm thop tensorboard ipdb h5py ipython Pillow==9.5.0 
 RUN pip install -U numpy 
@@ -9,3 +10,10 @@ RUN pip install -U numpy
 WORKDIR /completion_former 
 COPY . /completion_former
 RUN cd src/model/deformconv/ && CUDA_HOME=/usr/local/cuda-11.1/ python setup.py build install
+# nvidia apex
+RUN apt install -y wget unzip
+ARG COMMIT=4ef930c1c884fdca5f472ab2ce7cb9b505d26c1a
+RUN wget https://github.com/NVIDIA/apex/archive/${COMMIT}.zip && unzip ${COMMIT}.zip && \
+    rm ${COMMIT}.zip && cd apex-${COMMIT} && \
+    pip install -v --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" ./ 
+

--- a/README.md
+++ b/README.md
@@ -43,6 +43,31 @@ We ran our experiments with PyTorch 1.10.1, CUDA 11.3, Python 3.8 and Ubuntu 20.
 
 <!-- We recommend using a [conda environment](https://conda.io/docs/user-guide/tasks/manage-environments.html) to avoid dependency conflicts. -->
 
+#### Docker
+
+You can get started with docker by making sure you're default runtime is set to nvidia-container-runtime
+
+```bash
+# /etc/docker/daemon.json
+{
+    "runtimes": {
+        "nvidia": {
+            "path": "/usr/bin/nvidia-container-runtime",
+            "runtimeArgs": []
+         } 
+    },
+    "default-runtime": "nvidia" 
+}
+```
+
+Then you can build the image along with the DCNv2 cuda kernels with:
+
+```bash
+docker build -t completionformer:latest .
+# run container
+docker run --rm -it --gpus all completionformer
+```
+
 #### NVIDIA Apex
 
 We used NVIDIA Apex (commit @ 4ef930c1c884fdca5f472ab2ce7cb9b505d26c1a) for multi-GPU training.


### PR DESCRIPTION
Hey, first of all thanks for sharing your work, it looks promising!
I had a bit of struggle to get it to run with a more recent stack due to (mainly) the absence of the `THC.h` header in modern pytorch releases, needed to build the cuda functions.
I believe providing a very simple Dockerfile such as this could be helpful to get people started right away, as it includes the right cuda tools (devel image, so it comes with things like nvcc out of the box).

The image takes care of building the kernels on the platform, as long as `nvidia-container-runtime` is the default runtime:

```bash
# /etc/docker/daemon.json
{
    "runtimes": {
        "nvidia": {
            "path": "/usr/bin/nvidia-container-runtime",
            "runtimeArgs": []
         } 
    },
    "default-runtime": "nvidia" 
}
```